### PR TITLE
Tests Report on github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,15 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/test-results/test/TEST-*.xml
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,4 +48,14 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+
+	reports {
+        html.required.set(true)
+        junitXml.required.set(true) 
+    }
+
+	testLogging {
+        events("passed", "failed", "skipped")
+        showStandardStreams = false
+    }
 }


### PR DESCRIPTION
Set up GitHub Actions to run tests after the build process and generate detailed reports for the test results. This includes modifying the workflow to run the ./gradlew test command after building the project and configuring it to generate test result reports in XML format. The reports will be uploaded as artifacts, and a .zip file containing an HTML coverage report will be created and made available for download.

Requirements:

- Run tests with ./gradlew test after the build process.
- Capture test results in XML format.
- Upload the test result XML files as artifacts.
- Only display the relevant test output in the GitHub Actions logs.
- Generate a .zip file with the HTML test coverage report.
- Upload the .zip file as an artifact.
- Ensure the uploaded artifacts are accessible for download through the GitHub Actions interface.