### PR TITLE
Enable jpa auditing

### DIFF
--- a/src/main/java/com/iws_manager/iws_manager_api/IwsManagerApiApplication.java
+++ b/src/main/java/com/iws_manager/iws_manager_api/IwsManagerApiApplication.java
@@ -3,8 +3,10 @@ package com.iws_manager.iws_manager_api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication //(exclude = DataSourceAutoConfiguration.class)
+@EnableJpaAuditing
 @EntityScan(basePackages = "com.iws_manager.iws_manager_api.models")
 public class IwsManagerApiApplication {
 


### PR DESCRIPTION
Enable jpa auditing in order to have control of every entity for the methods:
- updatedAt
- createdAt